### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Veri5ight is a direct interface between Claude and Ethereum nodes, providing:
 - 🚀 Direct node access without rate limits
 - 🔒 Private, secure interactions
 
+<a href="https://glama.ai/mcp/servers/en31vxf492"><img width="380" height="200" src="https://glama.ai/mcp/servers/en31vxf492/badge" alt="Veri5ight Server MCP server" /></a>
+
 ## 🚀 Quick Start
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [Veri5ight MCP Server](https://glama.ai/mcp/servers/en31vxf492) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/en31vxf492"><img width="380" height="200" src="https://glama.ai/mcp/servers/en31vxf492/badge" alt="Veri5ight Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.